### PR TITLE
Fix production docs routing

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,6 @@
+{
+  "rewrites": [
+    { "source": "/docs(/.*)?", "destination": "/index.html" },
+    { "source": "/(.*)", "destination": "/index.html" }
+  ]
+}


### PR DESCRIPTION
## Summary
- add Vercel rewrite rules so all SPA routes fall back to `index.html`

## Testing
- `pnpm build:docs`

------
https://chatgpt.com/codex/tasks/task_e_684d701704f08323b627f6b16390b495